### PR TITLE
Added X-Forwarded-Proto to nginx-gecos.conf template

### DIFF
--- a/templates/nginx-gecoscc.conf
+++ b/templates/nginx-gecoscc.conf
@@ -5,14 +5,14 @@ upstream @app {
 
 server {
   listen  80;
-
-    server_name ${HOSTNAME};
+  server_name ${HOSTNAME};
 
   location / {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_redirect off;
       proxy_http_version 1.1;
+      proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
       proxy_pass http://@app;


### PR DESCRIPTION
This key is needed when using GECOSCC over https. Without it, https requests will translate as http and fail.