### PR TITLE
Necessary configurations added

### DIFF
--- a/templates/nginx-gecoscc.conf
+++ b/templates/nginx-gecoscc.conf
@@ -19,5 +19,8 @@ server {
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
       proxy_pass http://@app;
+
+      proxy_headers_hash_max_size 512;
+      proxy_headers_hash_bucket_size 128;
   }
 }


### PR DESCRIPTION
Without these values in some servers Nginx fails with the following error message:

  nginx: [emerg] could not build the proxy_headers_hash, you should increase either proxy_headers_hash_max_size: 512 or proxy_headers_hash_bucket_size: 64