### PR TITLE
Changes after updating Celery

### DIFF
--- a/templates/supervisord
+++ b/templates/supervisord
@@ -74,6 +74,9 @@ stop() {
         return $RETVAL
     fi
     rm -f $PID_FILE
+    
+    # Ensure that celery is stopped
+    killall -9 celery
     return $RETVAL
 }
 

--- a/templates/supervisord.conf
+++ b/templates/supervisord.conf
@@ -35,7 +35,8 @@ user=gecoscc
 
 [program:gecosccui-celery]
 autorestart=true
-command=/opt/gecosccui-${GECOSCC_VERSION}/bin/pceleryd /opt/gecosccui-${GECOSCC_VERSION}/gecoscc.ini
+command=/opt/gecosccui-${GECOSCC_VERSION}/bin/celery worker -E -A pyramid_celery.celery_app --ini /opt/gecosccui-${GECOSCC_VERSION}/gecoscc.ini
+stopsignal=KILL
 process_name=%(program_name)s
 numprocs=1
 redirect_stderr=true


### PR DESCRIPTION
Changes in the supervisor configuration to start and stop the Celery server after updating Celery to version  4.4.7 and pyramid-celery  module to version 3.0.0.