### PR TITLE
Fix permissions for .chef 

### DIFF
--- a/gecoscc-installer.sh
+++ b/gecoscc-installer.sh
@@ -793,7 +793,7 @@ fi
 
 
 chown -R $RUNUSER:$RUNGROUP $BASE
-chown -R $RUNUSER:$RUNGROUP /data/conf/.chef
+chown -R 42:$RUNGROUP /data/conf/.chef
 
 
 


### PR DESCRIPTION
User `gecoscc` doesn't have permissions to write in `/opt/gecosccui/.chef/`.